### PR TITLE
Add missing parameters in AlertWindow::showOkCancelBox

### DIFF
--- a/modules/juce_audio_processors/scanning/juce_PluginListComponent.cpp
+++ b/modules/juce_audio_processors/scanning/juce_PluginListComponent.cpp
@@ -302,7 +302,7 @@ PopupMenu PluginListComponent::createOptionsMenu()
                                         {
                                             auto title = "Remove all " + format->getName() + " plugins?";
                                             auto message = "Are you sure you want to remove all " + format->getName() + " plugins?";
-                                            if (AlertWindow::showOkCancelBox (AlertWindow::QuestionIcon, title, message, TRANS("Yes"), TRANS("No")))
+                                            if (AlertWindow::showOkCancelBox (AlertWindow::QuestionIcon, title, message, TRANS("Yes"), TRANS("No"), nullptr, nullptr))
                                                 for (auto& pd : list.getTypesForFormat (*format))
                                                     list.removeType (pd);
                                         }));


### PR DESCRIPTION
This PR fixes a build issue in juce_PluginListComponent.cpp where the call to `AlertWindow::showOkCancelBox` does not have the required number of parameters. Basically it's missing the `nullptr`s at the end. 


